### PR TITLE
Update actions/checkout and Use R-universe

### DIFF
--- a/cache-hubval-deps/cache-hubval-deps.yaml
+++ b/cache-hubval-deps/cache-hubval-deps.yaml
@@ -15,7 +15,7 @@ jobs:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: r-lib/actions/setup-r@v2
         with:

--- a/cache-hubval-deps/cache-hubval-deps.yaml
+++ b/cache-hubval-deps/cache-hubval-deps.yaml
@@ -21,6 +21,7 @@ jobs:
         with:
           install-r: false
           use-public-rspm: true
+          extra-repositories: 'https://hubverse-org.r-universe.dev'
 
       - name: Update R
         run: |
@@ -28,4 +29,6 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          packages: hubverse-org/hubValidations, any::sessioninfo
+          packages: |
+            any::hubValidations
+            any::sessioninfo

--- a/validate-submission/validate-submission.yaml
+++ b/validate-submission/validate-submission.yaml
@@ -16,7 +16,7 @@ jobs:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: r-lib/actions/setup-r@v2
         with:

--- a/validate-submission/validate-submission.yaml
+++ b/validate-submission/validate-submission.yaml
@@ -22,6 +22,7 @@ jobs:
         with:
           install-r: false
           use-public-rspm: true
+          extra-repositories: 'https://hubverse-org.r-universe.dev'
 
       - name: Update R
         run: |
@@ -29,7 +30,9 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          packages: hubverse-org/hubValidations, any::sessioninfo
+          packages: |
+            any::hubValidations
+            any::sessioninfo
 
       - name: Run validations
         env:


### PR DESCRIPTION
This will fix #21 by changing `actions/checkout@v3` to v4.

It also enables us to use the R-universe for package downloads by adding an `extra-repositories:` argument to the `setup-r` action and changing `hubverse-org/<pkg>` to `any::<pkg>`. 