### PR TITLE
update validate-config to use new ci function

### DIFF
--- a/validate-config/validate-config.yaml
+++ b/validate-config/validate-config.yaml
@@ -12,9 +12,9 @@ jobs:
   validate-hub-config:
     runs-on: ubuntu-latest
     env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
       PR_NUMBER: ${{ github.event.number }}
       HUB_PATH: ${{ github.workspace }}
-      DIFF_PATH: ${{ runner.temp }}/diff.md
 
     steps:
       - uses: actions/checkout@v4
@@ -38,7 +38,7 @@ jobs:
 
       - name: Run validations
         id: validate
-        run: hubAdmin::ci_validate_hub_config(diff = Sys.getenv("DIFF_PATH"))
+        run: hubAdmin::ci_validate_hub_config(diff = "${{ runner.temp }}/diff.md")
         shell: Rscript {0}
       - name: "Comment on PR"
         id: comment-diff
@@ -46,7 +46,7 @@ jobs:
         uses: carpentries/actions/comment-diff@main
         with:
           pr: ${{ env.PR_NUMBER }}
-          path: ${{ env.DIFF_PATH }}
+          path: ${{ runner.temp }}/diff.md
       - name: Error on Failure
         if: ${{ steps.validate.outputs.result == 'false' }}
         run: |

--- a/validate-config/validate-config.yaml
+++ b/validate-config/validate-config.yaml
@@ -12,9 +12,9 @@ jobs:
   validate-hub-config:
     runs-on: ubuntu-latest
     env:
-      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
       PR_NUMBER: ${{ github.event.number }}
       HUB_PATH: ${{ github.workspace }}
+      DIFF_PATH: ${{ runner.temp }}/diff.md
 
     steps:
       - uses: actions/checkout@v4
@@ -38,32 +38,7 @@ jobs:
 
       - name: Run validations
         id: validate
-        run: |
-          hub_path <- Sys.getenv("HUB_PATH")
-          diff <- file.path(hub_path, "diff.md")
-          output <- Sys.getenv("GITHUB_OUTPUT")
-          timestamp <- function(outfile) {
-            stamp <- format(Sys.time(), usetz = TRUE, tz = "UTC")
-            cat(stamp, "\n", file = outfile, sep = "", append = TRUE)
-          }
-          v <- hubAdmin::validate_hub_config(
-            hub_path = hub_path
-          )
-          # check if there were any failures
-          invalid <- any(vapply(v, isFALSE, logical(1)))
-          if (invalid) {
-            cat("result=false", "\n", file = output, sep = "", append = TRUE)
-            # write output to HTML
-            tbl <- hubAdmin::view_config_val_errors(v)
-            writeLines("## :x: Invalid Configuration\n", diff)
-            cat("\nErrors were detected in one or more config files in `hub-config/`. Details about the exact locations of the errors can be found in the table below.\n", file = diff, append = TRUE)
-            cat(gt::as_raw_html(tbl), "\n", file = diff, sep = "", append = TRUE)
-            timestamp(diff)
-          } else {
-            cat("result=true", "\n", file = output, sep = "", append = TRUE)
-            writeLines(":white_check_mark: Hub correctly configured!\n", diff)
-            timestamp(diff)
-          }
+        run: hubAdmin::ci_validate_hub_config(diff = Sys.getenv("DIFF_PATH"))
         shell: Rscript {0}
       - name: "Comment on PR"
         id: comment-diff
@@ -71,7 +46,7 @@ jobs:
         uses: carpentries/actions/comment-diff@main
         with:
           pr: ${{ env.PR_NUMBER }}
-          path: ${{ env.HUB_PATH }}/diff.md
+          path: ${{ env.DIFF_PATH }}
       - name: Error on Failure
         if: ${{ steps.validate.outputs.result == 'false' }}
         run: |


### PR DESCRIPTION
This updates the validate-config action to use the new [`ci_validate_hub_config()`](https://hubverse-org.github.io/hubAdmin/reference/ci_validate_hub_config.html) function.

I ran a test in my fork of the example hub and confirmed that it reports correctly: https://github.com/zkamvar/example-complex-forecast-hub/pull/2