### PR TITLE
Skip AWS upload job on forked repositories

### DIFF
--- a/hubverse-aws-upload/hubverse-aws-upload.yaml
+++ b/hubverse-aws-upload/hubverse-aws-upload.yaml
@@ -16,6 +16,8 @@ permissions:
 
 jobs:
   upload:
+    # Don't run on forked repositories
+    if: github.event.repository.fork != true
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Resolves #24. This approach was tested on the
variant-nowcast-hub repo, and the behavior was
as expected: the job is skipped on forked repos
but is executed on the upstream repo when teams
submit their forecasts.