### PR TITLE
Use github.event.repository.fork instead of checking repository owner when building package cache

### DIFF
--- a/cache-hubval-deps/README.md
+++ b/cache-hubval-deps/README.md
@@ -5,27 +5,3 @@ This hubverse action builds a cache of dependencies for the `hubValidations` pac
 
 The action is run on a `schedule` nightly at 00:10 UTC, rebuilding the cache if any dependencies have changed.
 It is also triggered by any `push` to the workflow file itself on the `main` branch  (i.e. `.github/workflows/cache-hubval-deps.yaml`). This ensures the workflow is triggered the first time it is added to the repo.
-
-## Restrict workflow to main Hub repository
-
-To ensure the workflow only runs on the main hub repository - so as not to use contributor resources unnecessarily - change the `if` statement on line 12 from:
-
-```yaml
-jobs:
-  build-deps-cache-on-main:
-    if: ${{ github.repository_owner == github.repository_owner }}
-```
-to 
-```yaml
-jobs:
-  build-deps-cache-on-main:
-    if: ${{ github.repository_owner == '<MAIN-HUB-REPO-OWNER-USERNAME>' }}
-```
-
-e.g. the following restricts the workflow to only run on repositories owned by `cdcepi`.
-
-```yaml
-jobs:
-  build-deps-cache-on-main:
-    if: ${{ github.repository_owner == 'cdcepi' }}
-```

--- a/cache-hubval-deps/cache-hubval-deps.yaml
+++ b/cache-hubval-deps/cache-hubval-deps.yaml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   build-deps-cache-on-main:
-    if: ${{ github.repository_owner == github.repository_owner }}
+    if: github.event.repository.fork != true
     runs-on: ubuntu-latest
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR resolves #28 by modifying `[cache-hubval-deps](https://github.com/hubverse-org/hubverse-actions/tree/main/cache-hubval-deps)` so that hub administrators do not need to edit the workflow to specify the owner of the upstream repo in order to ensure the workflow does not run on forks.

Instead the method described by @bsweger in https://github.com/hubverse-org/hubverse-actions/pull/26 of using `github.event.repository.fork` is introduced which does not require editing by hub admins.