### PR TITLE
Minor GitHub action security updates

### DIFF
--- a/cache-hubval-deps/cache-hubval-deps.yaml
+++ b/cache-hubval-deps/cache-hubval-deps.yaml
@@ -7,6 +7,9 @@ on:
   schedule:
     - cron: "10 0 * * *"
 
+permissions:
+  contents: read
+
 jobs:
   build-deps-cache-on-main:
     if: github.event.repository.fork != true

--- a/hubverse-aws-upload/hubverse-aws-upload.yaml
+++ b/hubverse-aws-upload/hubverse-aws-upload.yaml
@@ -46,7 +46,8 @@ jobs:
     - name: Install rclone
       if: env.CLOUD_ENABLED == 'true'
       run: |
-        curl https://rclone.org/install.sh | sudo bash
+        sudo apt-get update
+        sudo apt-get install -y rclone
         rclone version
 
     - name: Sync files to cloud storage

--- a/validate-config/validate-config.yaml
+++ b/validate-config/validate-config.yaml
@@ -8,6 +8,10 @@ on:
       - 'hub-config/**'
       - '!**README**'
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   validate-hub-config:
     runs-on: ubuntu-22.04

--- a/validate-submission/validate-submission.yaml
+++ b/validate-submission/validate-submission.yaml
@@ -9,6 +9,10 @@ on:
       - 'model-metadata/*'
       - '!**README**'
 
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
   validate-submission:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
Closes #33 

The above ticket has more information about these changes.
The PR and be reviewed commit by commit.

**Update 2025-03-19:** per our discussion at this morning's Hubverse dev meeting, this PR does not change github action tags to commit hashes. Note that all 3rd party actions used here are from trusted sources.